### PR TITLE
Fixes #12, fixes #11, fixes #5

### DIFF
--- a/library.js
+++ b/library.js
@@ -3,8 +3,6 @@
 
 	var Plugin = {};
 
-	// this method works now
-
 	Plugin.serveHomepage = function(params){
 		params.res.render('homepage', {
 			template: {
@@ -20,8 +18,6 @@
 		});
 		callback(null, data);
 	};
-
-	// yay
 
 	Plugin.addNavigation = function(header, callback) {
 		header.navigation.push(
@@ -64,47 +60,6 @@
 
 		callback(null, areas);
 	};
-
-	// trash
-
-	/* don't think this is necessary anymore either
-
-	var Meta = module.parent.require('./meta');
-	var Validator = require('validator');
-
-	function renderDefaultSiteDescription(req, res, next) {
-		res.locals.metaTags = [{
-			name: "description",
-			content: Validator.escape(Meta.config.description || '')
-		}];
-		next();
-	}
-
-	*/
-
-	/* don't even need the init hook anymore
-
-	Plugin.init = function(params, callback) {
-		var app = params.router;
-
-		// app.get('/', renderDefaultSiteDescription, params.middleware.buildHeader, renderHomepage);
-		// app.get('/api/', function(req, res, next) {
-		// 	res.json({
-		// 		template: {
-		// 			name: 'homepage'
-		// 		}
-		// 	});
-		// });
-
-		no longer necessary because of categories path
-		app.get('/forum', params.middleware.buildHeader, params.controllers.home);
-		app.get('/api/forum', params.controllers.home);
-
-
-		callback();
-	};
-
-	*/
 
 	module.exports = Plugin;
 }(module));

--- a/library.js
+++ b/library.js
@@ -2,34 +2,17 @@
 	"use strict";
 
 	var Plugin = {};
-	var Meta = module.parent.require('./meta');
-	var Validator = require('validator');
 
-	function renderDefaultSiteDescription(req, res, next) {
-		res.locals.metaTags = [{
-			name: "description",
-			content: Validator.escape(Meta.config.description || '')
-		}];
-		next();
-	}
+	// this method works now
 
-	function renderHomepage(req, res, next) {
-		res.render('homepage', {
+	Plugin.serveHomepage = function(params){
+		params.res.render('homepage', {
 			template: {
 				name: 'homepage'
 			}
 		});
-	}
-
-	// this method doesn't work
-	// and I don't know how to make it work
-	// but it would be the preferred way
-
-	Plugin.serveHomepage = function(params){
-		renderHomepage(params.req, params.res, params.next);
 	};
 
-	// this actually does work, but is useless without the above stuff working
 	Plugin.addListing = function(data, callback){
 		data.routes.push({
 			route: 'customHP',
@@ -38,27 +21,7 @@
 		callback(null, data);
 	};
 
-	// *sigh*
-
-	Plugin.init = function(params, callback) {
-		var app = params.router;
-
-		app.get('/', renderDefaultSiteDescription, params.middleware.buildHeader, renderHomepage);
-		app.get('/api/', function(req, res, next) {
-			res.json({
-				template: {
-					name: 'homepage'
-				}
-			});
-		});
-
-		/* no longer necessary because of categories path
-		app.get('/forum', params.middleware.buildHeader, params.controllers.home);
-		app.get('/api/forum', params.controllers.home);
-		*/
-
-		callback();
-	};
+	// yay
 
 	Plugin.addNavigation = function(header, callback) {
 		header.navigation.push(
@@ -101,6 +64,47 @@
 
 		callback(null, areas);
 	};
+
+	// trash
+
+	/* don't think this is necessary anymore either
+
+	var Meta = module.parent.require('./meta');
+	var Validator = require('validator');
+
+	function renderDefaultSiteDescription(req, res, next) {
+		res.locals.metaTags = [{
+			name: "description",
+			content: Validator.escape(Meta.config.description || '')
+		}];
+		next();
+	}
+
+	*/
+
+	/* don't even need the init hook anymore
+
+	Plugin.init = function(params, callback) {
+		var app = params.router;
+
+		// app.get('/', renderDefaultSiteDescription, params.middleware.buildHeader, renderHomepage);
+		// app.get('/api/', function(req, res, next) {
+		// 	res.json({
+		// 		template: {
+		// 			name: 'homepage'
+		// 		}
+		// 	});
+		// });
+
+		no longer necessary because of categories path
+		app.get('/forum', params.middleware.buildHeader, params.controllers.home);
+		app.get('/api/forum', params.controllers.home);
+
+
+		callback();
+	};
+
+	*/
 
 	module.exports = Plugin;
 }(module));

--- a/library.js
+++ b/library.js
@@ -5,10 +5,6 @@
 	var Meta = module.parent.require('./meta');
 	var Validator = require('validator');
 
-	function renderHomepage(req, res, next) {
-		res.render('homepage', {});
-	}
-
 	function renderDefaultSiteDescription(req, res, next) {
 		res.locals.metaTags = [{
 			name: "description",
@@ -17,18 +13,49 @@
 		next();
 	}
 
+	function renderHomepage(req, res, next) {
+		res.render('homepage', {
+			template: {
+				name: 'homepage'
+			}
+		});
+	}
+
+	// this method doesn't work
+	// and I don't know how to make it work
+	// but it would be the preferred way
+
+	Plugin.serveHomepage = function(params){
+		renderHomepage(params.req, params.res, params.next);
+	};
+
+	// this actually does work, but is useless without the above stuff working
+	Plugin.addListing = function(data, callback){
+		data.routes.push({
+			route: 'customHP',
+			name: 'Custom Homepage'
+		});
+		callback(null, data);
+	};
+
+	// *sigh*
+
 	Plugin.init = function(params, callback) {
-		var app = params.router,
-			middleware = params.middleware,
-			controllers = params.controllers;
+		var app = params.router;
 
 		app.get('/', renderDefaultSiteDescription, params.middleware.buildHeader, renderHomepage);
-		app.get('/api/home', function(req, res, next) {
-			res.json({});
+		app.get('/api/', function(req, res, next) {
+			res.json({
+				template: {
+					name: 'homepage'
+				}
+			});
 		});
 
+		/* no longer necessary because of categories path
 		app.get('/forum', params.middleware.buildHeader, params.controllers.home);
 		app.get('/api/forum', params.controllers.home);
+		*/
 
 		callback();
 	};
@@ -36,7 +63,7 @@
 	Plugin.addNavigation = function(header, callback) {
 		header.navigation.push(
 			{
-				route: '/forum',
+				route: '/categories',
 				class: '',
 				text: 'Forum',
 				iconClass: 'fa-comments',
@@ -45,7 +72,7 @@
 			}
 		);
 
-		callback(false, header);
+		callback(null, header);
 	};
 
 	Plugin.defineWidgetAreas = function(areas, callback) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nodebb-plugin-custom-homepage",
   "version": "0.1.17",
   "description": "Allows you to define a custom homepage for NodeBB",
-  "main": "library.js",
+  "main": "./library.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/plugin.json
+++ b/plugin.json
@@ -13,6 +13,12 @@
 		},
 		{
 			"hook": "filter:widgets.getAreas", "method": "defineWidgetAreas"
+		},
+		{
+			"hook": "action:homepage.get:customHP", "method": "serveHomepage"
+		},
+		{
+			"hook": "filter:homepage.get", "method": "addListing"
 		}
 	],
 	"templates": "./templates"

--- a/plugin.json
+++ b/plugin.json
@@ -6,9 +6,6 @@
 	"library": "./library.js",
 	"hooks": [
 		{
-			"hook": "static:app.load", "method": "init"
-		},
-		{
 			"hook": "filter:header.build", "method": "addNavigation"
 		},
 		{


### PR DESCRIPTION
Ajaxifying to the `/` route now goes to the custom homepage. The new breadcrumb now goes to the `categories` route. 

The better way to do this would be to get the hooks way to work, but I'm not able to do so at the moment for some reason. It does add a listing in the ACP dropdown for homepages, but it doesn't do anything.